### PR TITLE
use wp_kses_post instead of esc_html because we want to allow post ht…

### DIFF
--- a/classes/custom-callback.php
+++ b/classes/custom-callback.php
@@ -37,7 +37,7 @@ class CustomCallback extends \Elementor\Core\DynamicTags\Tag {
       $callback = $this->get_settings( 'callback' );
 
       if (is_callable($callback)) {
-          echo esc_html($callback($post));
+          echo wp_kses_post($callback($post));
       }
   }
 }

--- a/classes/parent-meta.php
+++ b/classes/parent-meta.php
@@ -102,7 +102,7 @@ Class ParentMeta extends \Elementor\Core\DynamicTags\Tag {
 
         $current = get_post();
         if ($current && $parent = get_post_parent($current)) {
-            echo esc_html(implode(",", get_post_meta($parent->ID, $meta_key)));
+            echo wp_kses_post(implode(",", get_post_meta($parent->ID, $meta_key)));
         }
     }
 }


### PR DESCRIPTION
…ml output