### PR TITLE
check for jet engine class to fix fatal error on edit with elementor

### DIFF
--- a/classes/parent-meta-image.php
+++ b/classes/parent-meta-image.php
@@ -15,11 +15,16 @@ class ParentMetaImage extends \Elementor\Core\DynamicTags\Data_Tag {
     }
 
     public function get_categories() {
-        return [
+        $cats = [
             \Elementor\Modules\DynamicTags\Module::IMAGE_CATEGORY,
             \Elementor\Modules\DynamicTags\Module::MEDIA_CATEGORY,
-            \Jet_Engine_Dynamic_Tags_Module::IMAGE_CATEGORY,
         ];
+
+        if (class_exists('Jet_Engine_Dynamic_Tags_Module')) {
+            $cats[] = \Jet_Engine_Dynamic_Tags_Module::IMAGE_CATEGORY;
+        }
+
+        return $cats;
     }
 
     protected function _register_controls() {


### PR DESCRIPTION
* when jet engine not installed, edit with elementor produces fatal error.
* check for jet engine class before accessing.